### PR TITLE
fix mktemp OSX compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,8 @@ before_script:
 language: ruby
 rvm:
   - 1.9.3
+  - 2.1.3
+  - 2.2.2
+  - head
 env:
   - CHEF_VERSION=10.12.0

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 chefversion = ENV.key?('CHEF_VERSION') ? "= #{ENV['CHEF_VERSION']}" : ['>= 10.12.0']
 
 gem 'chef', chefversion

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -10,7 +10,7 @@
 exec 1>&2
 
 FOODCRITIC_FLAGS=${FOODCRITIC_FLAGS:-"--epic-fail any"}
-TMPFILE=$(mktemp)
+TMPFILE=$(mktemp "${TMPDIR:-/tmp}/tmp.XXXXXXXXXX")
 STATUS=0
 
 # Register exit trap for removing temporary files


### PR DESCRIPTION
Just a small fix to use this with OSX.
More or less a copy of https://github.com/gini/puppet-git-hooks/pull/1